### PR TITLE
Feature/noaacloud 4zach

### DIFF
--- a/modulefiles/ufs_common_spack.lua
+++ b/modulefiles/ufs_common_spack.lua
@@ -1,0 +1,57 @@
+help([[
+loads UFS Model common libraries
+]])
+
+jasper_ver=os.getenv("jasper_ver") or "2.0.32"
+load(pathJoin("jasper", jasper_ver))
+
+zlib_ver=os.getenv("zlib_ver") or "1.2.13"
+load(pathJoin("zlib", zlib_ver))
+
+libpng_ver=os.getenv("libpng_ver") or "1.6.37"
+load(pathJoin("libpng", libpng_ver))
+
+hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
+load(pathJoin("hdf5", hdf5_ver))
+
+netcdf_ver=os.getenv("netcdf_ver") or "4.9.0"
+load(pathJoin("netcdf-c", netcdf_ver))
+load(pathJoin("netcdf-fortran", "4.6.0"))
+
+pio_ver=os.getenv("pio_ver") or "2.5.9"
+load(pathJoin("parallelio", pio_ver))
+
+esmf_ver=os.getenv("esmf_ver") or "8.3.0b09"
+load(pathJoin("esmf", esmf_ver))
+
+fms_ver=os.getenv("fms_ver") or "2022.04"
+load(pathJoin("fms",fms_ver))
+
+bacio_ver=os.getenv("bacio_ver") or "2.4.1"
+load(pathJoin("bacio", bacio_ver))
+
+crtm_ver=os.getenv("crtm_ver") or "2.4.0"
+load(pathJoin("crtm", crtm_ver))
+
+g2_ver=os.getenv("g2_ver") or "3.4.5"
+load(pathJoin("g2", g2_ver))
+
+g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.10.2"
+load(pathJoin("g2tmpl", g2tmpl_ver))
+
+ip_ver=os.getenv("ip_ver") or "3.3.3"
+load(pathJoin("ip", ip_ver))
+
+sp_ver=os.getenv("sp_ver") or "2.3.3"
+load(pathJoin("sp", sp_ver))
+
+w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
+load(pathJoin("w3emc", w3emc_ver))
+
+gftl_shared_ver=os.getenv("gftl_shared_ver") or "v1.5.0"
+load(pathJoin("gftl-shared", gftl_shared_ver))
+
+mapl_ver=os.getenv("mapl_ver") or "2.22.0-esmf-8.3.0b09"
+load(pathJoin("mapl", mapl_ver))
+
+whatis("Description: UFS build environment common libraries")

--- a/modulefiles/ufs_common_spack_debug.lua
+++ b/modulefiles/ufs_common_spack_debug.lua
@@ -1,0 +1,57 @@
+help([[
+loads UFS Model common libraries
+]])
+
+jasper_ver=os.getenv("jasper_ver") or "2.0.32"
+load(pathJoin("jasper", jasper_ver))
+
+zlib_ver=os.getenv("zlib_ver") or "1.2.13"
+load(pathJoin("zlib", zlib_ver))
+
+libpng_ver=os.getenv("libpng_ver") or "1.6.37"
+load(pathJoin("libpng", libpng_ver))
+
+hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
+load(pathJoin("hdf5", hdf5_ver))
+
+netcdf_ver=os.getenv("netcdf_ver") or "4.9.0"
+load(pathJoin("netcdf-c", netcdf_ver))
+load(pathJoin("netcdf-fortran", "4.6.0"))
+
+pio_ver=os.getenv("pio_ver") or "2.5.9"
+load(pathJoin("parallelio", pio_ver))
+
+esmf_ver=os.getenv("esmf_ver") or "8.3.0b09-debug"
+load(pathJoin("esmf", esmf_ver))
+
+fms_ver=os.getenv("fms_ver") or "2022.04"
+load(pathJoin("fms",fms_ver))
+
+bacio_ver=os.getenv("bacio_ver") or "2.4.1"
+load(pathJoin("bacio", bacio_ver))
+
+crtm_ver=os.getenv("crtm_ver") or "2.4.0"
+load(pathJoin("crtm", crtm_ver))
+
+g2_ver=os.getenv("g2_ver") or "3.4.5"
+load(pathJoin("g2", g2_ver))
+
+g2tmpl_ver=os.getenv("g2tmpl_ver") or "1.10.2"
+load(pathJoin("g2tmpl", g2tmpl_ver))
+
+ip_ver=os.getenv("ip_ver") or "3.3.3"
+load(pathJoin("ip", ip_ver))
+
+sp_ver=os.getenv("sp_ver") or "2.3.3"
+load(pathJoin("sp", sp_ver))
+
+w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
+load(pathJoin("w3emc", w3emc_ver))
+
+gftl_shared_ver=os.getenv("gftl_shared_ver") or "v1.5.0"
+load(pathJoin("gftl-shared", gftl_shared_ver))
+
+mapl_ver=os.getenv("mapl_ver") or "2.22.0-debug-esmf-8.3.0b09-debug"
+load(pathJoin("mapl", mapl_ver))
+
+whatis("Description: UFS build environment common libraries")

--- a/modulefiles/ufs_noaacloud.intel.lua
+++ b/modulefiles/ufs_noaacloud.intel.lua
@@ -1,0 +1,22 @@
+help([[
+loads UFS Model prerequisites for noaacloud/intel
+]])
+
+
+prepend_path("MODULEPATH", "/contrib/EPIC/spack-stack/spack-stack-1.3.0/envs/unified-dev/install/modulefiles/Core")
+
+load("stack-intel/2021.3.0")
+load("stack-intel-oneapi-mpi/2021.3.0")
+load("stack-python/3.9.12")
+load("cmake/3.23.1")
+
+load("ufs_common_spack")
+
+setenv("CC", "mpiicc")
+setenv("CXX", "mpiicpc")
+setenv("FC", "mpiifort")
+setenv("CMAKE_Platform", "noaacloud.intel")
+
+whatis("Description: UFS build environment")
+
+

--- a/modulefiles/ufs_noaacloud.intel_debug.lua
+++ b/modulefiles/ufs_noaacloud.intel_debug.lua
@@ -1,0 +1,22 @@
+help([[
+loads UFS Model prerequisites for noaacloud/intel
+]])
+
+
+prepend_path("MODULEPATH", "/contrib/EPIC/spack-stack/spack-stack-1.3.0/envs/unified-dev/install/modulefiles/Core")
+
+load("stack-intel/2021.3.0")
+load("stack-intel-oneapi-mpi/2021.3.0")
+load("stack-python/3.9.12")
+load("cmake/3.23.1")
+
+load("ufs_common_spack_debug")
+
+setenv("CC", "mpiicc")
+setenv("CXX", "mpiicpc")
+setenv("FC", "mpiifort")
+setenv("CMAKE_Platform", "noaacloud.intel")
+
+whatis("Description: UFS build environment")
+
+

--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -269,6 +269,67 @@ elif [[ $MACHINE_ID = expanse.* ]]; then
   TPN_cpl_atmw_gdas=12; INPES_cpl_atmw_gdas=6; JNPES_cpl_atmw_gdas=8
   THRD_cpl_atmw_gdas=2; WPG_cpl_atmw_gdas=24; APB_cpl_atmw_gdas="0 311"; WPB_cpl_atmw_gdas="312 559"
 
+elif [[ $MACHINE_ID = noaacloud.* ]]; then
+
+  if [[ $PW_CSP_ID = aws ]]; then
+  
+    TPN=36
+  
+    INPES_dflt=3 ; JNPES_dflt=8
+    INPES_thrd=3 ; JNPES_thrd=4
+    
+    THRD_cpl_dflt=1
+    INPES_cpl_dflt=3; JNPES_cpl_dflt=8; WPG_cpl_dflt=6
+    OCN_tasks_cpl_dflt=20
+    ICE_tasks_cpl_dflt=10
+    WAV_tasks_cpl_dflt=20
+    
+    THRD_cpl_thrd=2
+    INPES_cpl_thrd=3; JNPES_cpl_thrd=4; WPG_cpl_thrd=6
+    OCN_tasks_cpl_thrd=20
+    ICE_tasks_cpl_thrd=10
+    WAV_tasks_cpl_thrd=12
+    
+  elif [[ $PW_CSP_ID = azure ]]; then
+  
+    TPN=44
+  
+    INPES_dflt=3 ; JNPES_dflt=8
+    INPES_thrd=3 ; JNPES_thrd=4
+    
+    THRD_cpl_dflt=1
+    INPES_cpl_dflt=3; JNPES_cpl_dflt=8; WPG_cpl_dflt=6
+    OCN_tasks_cpl_dflt=20
+    ICE_tasks_cpl_dflt=10
+    WAV_tasks_cpl_dflt=20
+    
+    THRD_cpl_thrd=2
+    INPES_cpl_thrd=3; JNPES_cpl_thrd=4; WPG_cpl_thrd=6
+    OCN_tasks_cpl_thrd=20
+    ICE_tasks_cpl_thrd=10
+    WAV_tasks_cpl_thrd=12
+    
+  elif [[ $PW_CSP_ID = gcp ]]; then
+  
+    TPN=30
+  
+    INPES_dflt=3 ; JNPES_dflt=8
+    INPES_thrd=3 ; JNPES_thrd=4
+    
+    THRD_cpl_dflt=1
+    INPES_cpl_dflt=3; JNPES_cpl_dflt=8; WPG_cpl_dflt=6
+    OCN_tasks_cpl_dflt=20
+    ICE_tasks_cpl_dflt=10
+    WAV_tasks_cpl_dflt=20
+    
+    THRD_cpl_thrd=2
+    INPES_cpl_thrd=3; JNPES_cpl_thrd=4; WPG_cpl_thrd=6
+    OCN_tasks_cpl_thrd=20
+    ICE_tasks_cpl_thrd=10
+    WAV_tasks_cpl_thrd=12
+  
+  fi
+  
 else
 
   echo "Unknown MACHINE_ID ${MACHINE_ID}"

--- a/tests/detect_machine.sh
+++ b/tests/detect_machine.sh
@@ -104,6 +104,15 @@ case $(hostname -f) in
   login02.expanse.sdsc.edu) MACHINE_ID=expanse ;; ### expanse2
 esac
 
+case $(echo $PW_CSP) in
+
+  aws) PW_CSP_ID=aws ;; ### parallelworks aws
+  google) PW_CSP_ID=gcp ;; ### parallelworks gcp
+  azure) PW_CSP_ID=azure ;; ### parallelworks azure
+  
+esac
+[[ ${PW_CSP_ID} =~ "aws" || ${PW_CSP_ID} =~ "gcp" || ${PW_CSP_ID} =~ "azure" ]] && MACHINE_ID=noaacloud
+
 # Overwrite auto-detect with RT_MACHINE if set
 MACHINE_ID=${RT_MACHINE:-${MACHINE_ID}}
 


### PR DESCRIPTION
Add noaacloud modulefiles & ufs common file (uses spack unified-environment versions)
- Update `detect_machine.sh` and `default_vars.sh` so that both generalized noaacloud fv3conf, modulefiles, and logic stanzas can be utilized, but also retain specific CSP ID so that comp. tasks can be properly allocated.